### PR TITLE
Add input validation in Tad contracts

### DIFF
--- a/contracts/Governance/Tad.sol
+++ b/contracts/Governance/Tad.sol
@@ -82,9 +82,16 @@ contract Tad {
      * @param spender The address of the account which may transfer tokens
      * @param rawAmount The number of tokens that are approved (2^256-1 means infinite)
      * @return Whether or not the approval succeeded
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
      */
     function approve(address spender, uint rawAmount) external returns (bool) {
         uint96 amount;
+        require(msg.sender != address(0), "Comp::approve: approve from the zero address");
+        require(spender != address(0), "Comp::approve: approve to the zero address");
         if (rawAmount == uint(-1)) {
             amount = uint96(-1);
         } else {

--- a/contracts/Governance/Tad.sol
+++ b/contracts/Governance/Tad.sol
@@ -238,23 +238,9 @@ contract Tad {
     }
     
     
-    /**
-     * @dev Moves tokens `amount` from `src` to `dst`.
-     *
-     * This is internal function is equivalent to {transfer}, and can be used to
-     * e.g. implement automatic token fees, slashing mechanisms, etc.
-     *
-     * Emits a {Transfer} event.
-     *
-     * Requirements:
-     *
-     * - `src` cannot be the zero address.
-     * - `dst` cannot be the zero address.
-     * - `src` must have a balance of at least `amount`.
-     */
     function _transferTokens(address src, address dst, uint96 amount) internal {
         require(src != address(0), "Comp::_transferTokens: cannot transfer from the zero address");
-        require(dst != address(0), "Comp::_transferTokens: cannot transfer to the zero address");
+        //require(dst != address(0), "Comp::_transferTokens: cannot transfer to the zero address");
 
         balances[src] = sub96(balances[src], amount, "Comp::_transferTokens: transfer amount exceeds balance");
         if(dst != address(0)) balances[dst] = add96(balances[dst], amount, "Comp::_transferTokens: transfer amount overflows");

--- a/contracts/Governance/Tad.sol
+++ b/contracts/Governance/Tad.sol
@@ -236,10 +236,25 @@ contract Tad {
 
         _moveDelegates(currentDelegate, delegatee, delegatorBalance);
     }
-
+    
+    
+    /**
+     * @dev Moves tokens `amount` from `src` to `dst`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `src` cannot be the zero address.
+     * - `dst` cannot be the zero address.
+     * - `src` must have a balance of at least `amount`.
+     */
     function _transferTokens(address src, address dst, uint96 amount) internal {
         require(src != address(0), "Comp::_transferTokens: cannot transfer from the zero address");
-        //require(dst != address(0), "Comp::_transferTokens: cannot transfer to the zero address");
+        require(dst != address(0), "Comp::_transferTokens: cannot transfer to the zero address");
 
         balances[src] = sub96(balances[src], amount, "Comp::_transferTokens: transfer amount exceeds balance");
         if(dst != address(0)) balances[dst] = add96(balances[dst], amount, "Comp::_transferTokens: transfer amount overflows");


### PR DESCRIPTION
- Ensure that the spender address is not zero in contracts/Governance/Tad.sol Approve function